### PR TITLE
feat: encrypted repository support (v2, v4) and manual sync button/command

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,159 @@
+// Seafile client-side encryption (enc_version 2 and 4 only).
+// Algorithm reference: haiwen/seafile common/seafile-crypt.c.
+//
+// v2: fixed 8-byte salt baked into the protocol.
+// v4: per-repo random 32-byte salt (hex-encoded on the wire).
+// Both use PBKDF2-HMAC-SHA256 + AES-256-CBC (PKCS7).
+
+const FIXED_SALT_V2 = new Uint8Array([0xda, 0x90, 0x45, 0xc3, 0x06, 0xc7, 0xcc, 0x26]);
+
+export class UnsupportedEncVersionError extends Error {
+	constructor (version: number) {
+		super(`Unsupported encryption version ${version}. Only v2 and v4 are supported.`);
+	}
+}
+
+export class WrongPasswordError extends Error {
+	constructor () { super("Incorrect repository password."); }
+}
+
+function hexToBytes (hex: string): Uint8Array {
+	if (hex.length % 2 !== 0) throw new Error("Invalid hex string");
+	const out = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < out.length; i++) {
+		out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	}
+	return out;
+}
+
+function bytesToHex (bytes: Uint8Array | ArrayBuffer): string {
+	const u = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+	let s = "";
+	for (let i = 0; i < u.length; i++) s += u[i].toString(16).padStart(2, "0");
+	return s;
+}
+
+function timingSafeEqualHex (a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	return diff === 0;
+}
+
+function saltForVersion (version: number, repoSalt: string): Uint8Array {
+	if (version === 2) return FIXED_SALT_V2;
+	if (version === 4) {
+		if (!repoSalt) throw new Error("v4 encryption requires repo_salt");
+		return hexToBytes(repoSalt);
+	}
+	throw new UnsupportedEncVersionError(version);
+}
+
+async function pbkdf2 (data: Uint8Array, salt: Uint8Array, iterations: number, bits: number): Promise<Uint8Array> {
+	const baseKey = await crypto.subtle.importKey("raw", data, { name: "PBKDF2" }, false, ["deriveBits"]);
+	const derived = await crypto.subtle.deriveBits(
+		{ name: "PBKDF2", salt, iterations, hash: "SHA-256" },
+		baseKey,
+		bits
+	);
+	return new Uint8Array(derived);
+}
+
+// Two-step derivation matches seafile_derive_key for v >= 2:
+//   key = PBKDF2(data, salt, 1000, 32 bytes)
+//   iv  = PBKDF2(key,  salt, 10,   16 bytes)
+async function deriveKeyIv (data: Uint8Array, version: number, repoSalt: string): Promise<{ key: Uint8Array, iv: Uint8Array }> {
+	const salt = saltForVersion(version, repoSalt);
+	const key = await pbkdf2(data, salt, 1000, 32 * 8);
+	const iv = await pbkdf2(key, salt, 10, 16 * 8);
+	return { key, iv };
+}
+
+// magic = hex(first 32 bytes of key derived from `repo_id + password`).
+export async function computeMagic (repoId: string, password: string, version: number, repoSalt: string): Promise<string> {
+	const data = new TextEncoder().encode(repoId + password);
+	const { key } = await deriveKeyIv(data, version, repoSalt);
+	return bytesToHex(key);
+}
+
+export async function verifyPassword (repoId: string, password: string, version: number, repoSalt: string, magic: string): Promise<boolean> {
+	const computed = await computeMagic(repoId, password, version, repoSalt);
+	return timingSafeEqualHex(computed, magic);
+}
+
+async function aesCbcDecrypt (key: Uint8Array, iv: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+	const k = await crypto.subtle.importKey("raw", key, { name: "AES-CBC" }, false, ["decrypt"]);
+	const out = await crypto.subtle.decrypt({ name: "AES-CBC", iv }, k, data);
+	return new Uint8Array(out);
+}
+
+async function aesCbcEncrypt (key: Uint8Array, iv: Uint8Array, data: Uint8Array | ArrayBuffer): Promise<Uint8Array> {
+	const k = await crypto.subtle.importKey("raw", key, { name: "AES-CBC" }, false, ["encrypt"]);
+	const out = await crypto.subtle.encrypt({ name: "AES-CBC", iv }, k, data);
+	return new Uint8Array(out);
+}
+
+// Unwrap the random_key (48 hex bytes wrapped) using the password-derived key/iv,
+// then derive the actual block-encryption (encKey, encIV) from the unwrapped 32-byte secret.
+async function deriveBlockKeys (password: string, randomKeyHex: string, version: number, repoSalt: string): Promise<{ encKey: Uint8Array, encIv: Uint8Array }> {
+	const passData = new TextEncoder().encode(password);
+	const { key: pwKey, iv: pwIv } = await deriveKeyIv(passData, version, repoSalt);
+
+	const wrapped = hexToBytes(randomKeyHex);
+	if (wrapped.length !== 48) throw new Error(`Unexpected random_key length ${wrapped.length}, expected 48`);
+
+	let secret: Uint8Array;
+	try {
+		secret = await aesCbcDecrypt(pwKey, pwIv, wrapped);
+	} catch {
+		throw new WrongPasswordError();
+	}
+	if (secret.length !== 32) throw new Error(`Unwrapped secret has length ${secret.length}, expected 32`);
+
+	const { key: encKey, iv: encIv } = await deriveKeyIv(secret, version, repoSalt);
+	return { encKey, encIv };
+}
+
+export interface RepoCryptoMetadata {
+  encVersion: number
+  repoSalt: string
+  magic: string
+  randomKey: string
+  repoId: string
+}
+
+export class RepoCrypto {
+	private encKey?: Uint8Array;
+	private encIv?: Uint8Array;
+
+	private constructor (public readonly meta: RepoCryptoMetadata) {
+		if (meta.encVersion !== 2 && meta.encVersion !== 4) {
+			throw new UnsupportedEncVersionError(meta.encVersion);
+		}
+	}
+
+	static async unlock (meta: RepoCryptoMetadata, password: string): Promise<RepoCrypto> {
+		const ok = await verifyPassword(meta.repoId, password, meta.encVersion, meta.repoSalt, meta.magic);
+		if (!ok) throw new WrongPasswordError();
+
+		const { encKey, encIv } = await deriveBlockKeys(password, meta.randomKey, meta.encVersion, meta.repoSalt);
+		const c = new RepoCrypto(meta);
+		c.encKey = encKey;
+		c.encIv = encIv;
+		return c;
+	}
+
+	get isUnlocked (): boolean { return !!(this.encKey && this.encIv); }
+
+	async encryptBlock (plaintext: ArrayBuffer): Promise<ArrayBuffer> {
+		if (!this.encKey || !this.encIv) throw new Error("RepoCrypto not unlocked");
+		const out = await aesCbcEncrypt(this.encKey, this.encIv, plaintext);
+		return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength);
+	}
+
+	async decryptBlock (ciphertext: ArrayBuffer): Promise<ArrayBuffer> {
+		if (!this.encKey || !this.encIv) throw new Error("RepoCrypto not unlocked");
+		const out = await aesCbcDecrypt(this.encKey, this.encIv, new Uint8Array(ciphertext));
+		return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import Server from "./server";
 import { DEFAULT_SETTINGS, type SeafileSettings } from "./settings";
 import { SyncController } from "./sync/controller";
 import { Explorer } from "./ui/explorer";
+import PasswordModal from "./ui/password_modal";
 import { SeafileSettingTab } from "./ui/setting_tab";
 import { disableDebugConsole } from "./utils";
 
@@ -81,6 +82,13 @@ export default class SeafilePlugin extends Plugin {
 		this.settings.enableSync = true;
 		await this.saveSettings();
 		if (this.sync.status.type !== "stop") return;
+
+		const ok = await this.ensureUnlocked();
+		if (!ok) {
+			new Notice("Sync not started: encrypted repository is locked.");
+			return;
+		}
+
 		await this.sync.init();
 		this.sync.startSync();
 	}
@@ -91,6 +99,33 @@ export default class SeafilePlugin extends Plugin {
 			return true;
 		}
 		return false;
+	}
+
+	// Resolves true once the repo is ready to sync (plain repo, or encrypted-and-unlocked).
+	// Resolves false if the user cancelled the password prompt.
+	async ensureUnlocked(): Promise<boolean> {
+		if (!this.settings.encrypted) return true;
+		if (this.server.crypto) return true;
+
+		if (this.settings.encVersion !== 2 && this.settings.encVersion !== 4) {
+			new Notice(`Encryption version ${this.settings.encVersion} is not supported.`);
+			return false;
+		}
+
+		return await new Promise<boolean>((resolve) => {
+			new PasswordModal(this.app, {
+				repoId: this.settings.repoId,
+				encVersion: this.settings.encVersion,
+				repoSalt: this.settings.repoSalt,
+				magic: this.settings.repoMagic,
+				randomKey: this.settings.randomKey
+			}, (crypto) => {
+				this.server.crypto = crypto;
+				resolve(true);
+			}, () => {
+				resolve(false);
+			}).open();
+		});
 	}
 
 	async clearVault(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,12 @@ export default class SeafilePlugin extends Plugin {
 
 		this.addSettingTab(new SeafileSettingTab(this.app, this));
 
+		this.addCommand({
+			id: "manual-sync",
+			name: "Sync now",
+			callback: async () => { await this.triggerManualSync(); },
+		});
+
 		if (this.settings.devMode) {
 			(window as any)["seafile"] = this; // for debug
 			this.addRibbonIcon("trash-2", "Clear vault", async () => {
@@ -91,6 +97,29 @@ export default class SeafilePlugin extends Plugin {
 
 		await this.sync.init();
 		this.sync.startSync();
+	}
+
+	async triggerManualSync(): Promise<void> {
+		if (!this.settings.enableSync) {
+			new Notice("Enable sync first to use manual sync");
+			return;
+		}
+		if (!this.checkSyncReady()) {
+			if (!this.settings.authToken) {
+				new Notice("Log in first before syncing");
+			} else if (!this.settings.repoId) {
+				new Notice("Choose a repository first before syncing");
+			} else {
+				new Notice("Sync is not ready");
+			}
+			return;
+		}
+		if (this.sync.status.type === "busy") {
+			new Notice("Sync already in progress");
+			return;
+		}
+		this.sync.startSync();
+		new Notice("Sync started");
 	}
 
 	checkSyncReady(): boolean {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { type SeafileSettings } from "./settings";
 import * as utils from "./utils";
 import pako from "pako";
 import { posix as Path } from "path-browserify";
+import { type RepoCrypto } from "./crypto";
 
 export const ZeroFs = "0000000000000000000000000000000000000000";
 export type SeafFs = FileSeafFs | DirSeafFs
@@ -126,7 +127,18 @@ export class MfaRequiredError extends Error {
 	}
 }
 
+export interface RepoDownloadInfo {
+  token: string
+  encrypted: boolean
+  enc_version: number
+  magic: string
+  random_key: string
+  salt: string
+}
+
 export default class Server {
+	public crypto: RepoCrypto | null = null;
+
 	public constructor (private readonly settings: SeafileSettings,
     private readonly plugin: SeafilePlugin
 	) {
@@ -269,8 +281,20 @@ export default class Server {
 	}
 
 	async getRepoToken (repoId: string): Promise<string> {
+		const info = await this.getRepoDownloadInfo(repoId);
+		return info.token;
+	}
+
+	async getRepoDownloadInfo (repoId: string): Promise<RepoDownloadInfo> {
 		const resp = await this.requestAPIv20({ url: `repos/${repoId}/download-info/`, responseType: "json" });
-		return resp.token;
+		return {
+			token: resp.token,
+			encrypted: !!resp.encrypted,
+			enc_version: resp.enc_version ?? 0,
+			magic: resp.magic ?? "",
+			random_key: resp.random_key ?? "",
+			salt: resp.salt ?? ""
+		};
 	}
 
 	async getDirInfo (path: string, recursive = false): Promise<DirInfo[]> {
@@ -613,7 +637,10 @@ export default class Server {
 				url: `repo/${this.settings.repoId}/block/${blockId}`,
 				responseType: "binary",
 				retry: 0
-			});
+			}) as ArrayBuffer;
+		if (this.crypto) {
+			return await this.crypto.decryptBlock(resp);
+		}
 		return resp;
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,13 @@ export interface SeafileSettings {
   devMode: boolean
   enableSync: boolean
   useFetch: boolean
+
+  // Encryption metadata (public, server-supplied). Password is never persisted.
+  encrypted: boolean
+  encVersion: number
+  repoSalt: string
+  repoMagic: string
+  randomKey: string
 }
 
 export const DEFAULT_SETTINGS: SeafileSettings = {
@@ -28,4 +35,9 @@ export const DEFAULT_SETTINGS: SeafileSettings = {
 	devMode: false,
 	enableSync: false,
 	useFetch: false,
+	encrypted: false,
+	encVersion: 0,
+	repoSalt: "",
+	repoMagic: "",
+	randomKey: "",
 };

--- a/src/sync/controller.ts
+++ b/src/sync/controller.ts
@@ -339,7 +339,9 @@ export class SyncController {
 		} else {
 			// to do: warn if file too large
 			const buffer = await this.adapter.readBinary(path);
-			blockBuffer = await utils.computeBlocks(buffer);
+			blockBuffer = server.crypto
+				? await utils.computeBlocksEncrypted(buffer, (chunk) => server.crypto!.encryptBlock(chunk))
+				: await utils.computeBlocks(buffer);
 
 			fs = {
 				block_ids: Object.keys(blockBuffer),

--- a/src/ui/password_modal.ts
+++ b/src/ui/password_modal.ts
@@ -1,0 +1,73 @@
+import { App, Modal, Notice, Setting, type ButtonComponent } from "obsidian";
+import { RepoCrypto, type RepoCryptoMetadata, WrongPasswordError } from "../crypto";
+import { debug } from "../utils";
+
+export type PasswordCallback = (crypto: RepoCrypto) => Promise<void> | void;
+
+export default class PasswordModal extends Modal {
+	private password = "";
+	private submitBtn: ButtonComponent | null = null;
+
+	constructor (app: App,
+        private readonly meta: RepoCryptoMetadata,
+        private readonly callback: PasswordCallback,
+        private readonly onCancel?: () => void) {
+		super(app);
+	}
+
+	onOpen (): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		this.titleEl.textContent = "Unlock encrypted repository";
+		contentEl.createEl("p", {
+			text: "Enter the repository password. It is held in memory only and never written to disk."
+		});
+
+		new Setting(contentEl)
+			.setName("Password")
+			.addText(text => {
+				text.inputEl.type = "password";
+				text.setPlaceholder("password");
+				text.onChange(v => {
+					this.password = v;
+					this.submitBtn?.setDisabled(!v);
+				});
+				text.inputEl.addEventListener("keydown", (e) => {
+					if (e.key === "Enter" && this.password) void this.submit();
+				});
+			});
+
+		new Setting(contentEl)
+			.addButton(btn => {
+				this.submitBtn = btn;
+				btn.setButtonText("Unlock").setDisabled(true);
+				btn.onClick(() => void this.submit());
+			})
+			.addButton(btn => btn.setButtonText("Cancel").onClick(() => this.close()));
+	}
+
+	private cancelled = true;
+	private async submit (): Promise<void> {
+		if (!this.password) return;
+		this.submitBtn?.setDisabled(true);
+		try {
+			const crypto = await RepoCrypto.unlock(this.meta, this.password);
+			this.cancelled = false;
+			await this.callback(crypto);
+			this.close();
+		} catch (e) {
+			if (e instanceof WrongPasswordError) {
+				new Notice("Incorrect password");
+			} else {
+				new Notice("Unlock failed: " + (e as Error).message);
+				debug.error(e);
+			}
+			this.submitBtn?.setDisabled(false);
+		}
+	}
+
+	onClose (): void {
+		this.password = "";
+		if (this.cancelled) this.onCancel?.();
+	}
+}

--- a/src/ui/repo_modal.ts
+++ b/src/ui/repo_modal.ts
@@ -1,19 +1,25 @@
 import { App, Modal, Notice, Setting } from "obsidian";
 import { server } from "src/config";
-import { Repo } from "src/server";
+import { Repo, type RepoDownloadInfo } from "src/server";
 import { debug } from "src/utils";
 import prettyBytes from "pretty-bytes";
 
+export interface SelectedRepo {
+  repoName: string
+  repoId: string
+  info: RepoDownloadInfo
+}
+
 export default class RepoModal extends Modal {
 
-	constructor(app: App, private callback: (repoName: string, repoId: string, repoToken: string) => void) {
+	constructor(app: App, private callback: (selected: SelectedRepo) => void | Promise<void>) {
 		super(app);
 	}
 
 	async loadRepoToken(repo: Repo) {
 		try {
-			const repoToken = await server.getRepoToken(repo.repo_id);
-			this.callback(repo.repo_name, repo.repo_id, repoToken);
+			const info = await server.getRepoDownloadInfo(repo.repo_id);
+			await this.callback({ repoName: repo.repo_name, repoId: repo.repo_id, info });
 		}
 		catch (error) {
 			new Notice("Failed to load repository token. " + error.message);

--- a/src/ui/setting_tab.ts
+++ b/src/ui/setting_tab.ts
@@ -1,8 +1,10 @@
 import { type App, type ButtonComponent, Notice, PluginSettingTab, Setting, type TextAreaComponent, type TextComponent } from "obsidian";
 import type SeafilePlugin from "src/main";
 import { debug } from "src/utils";
+import { server } from "src/config";
 import Dialog from "./dialog_modal";
 import LoginModal from "./login_modal";
+import PasswordModal from "./password_modal";
 import RepoModal from "./repo_modal";
 
 export class SeafileSettingTab extends PluginSettingTab {
@@ -61,6 +63,12 @@ export class SeafileSettingTab extends PluginSettingTab {
 						settings.repoName = "";
 						settings.repoId = "";
 						settings.repoToken = "";
+						settings.encrypted = false;
+						settings.encVersion = 0;
+						settings.repoSalt = "";
+						settings.repoMagic = "";
+						settings.randomKey = "";
+						server.crypto = null;
 						await this.plugin.saveSettings();
 						accountButton.setButtonText("Log in");
 						accountSetting.setDesc(accountDefaultDesc);
@@ -99,17 +107,49 @@ export class SeafileSettingTab extends PluginSettingTab {
 						settings.repoName = "";
 						settings.repoId = "";
 						settings.repoToken = "";
+						settings.encrypted = false;
+						settings.encVersion = 0;
+						settings.repoSalt = "";
+						settings.repoMagic = "";
+						settings.randomKey = "";
+						server.crypto = null;
 						repoSetting.setDesc(repoDefaultDesc);
 						await this.plugin.saveSettings();
 					}
-					new RepoModal(this.app, async (repoName, repoId, repoToken) => {
-						settings.repoName = repoName;
-						settings.repoId = repoId;
-						settings.repoToken = repoToken;
-						repoSetting.setDesc(repoName);
-						await this.plugin.saveSettings();
+					new RepoModal(this.app, async ({ repoName, repoId, info }) => {
+						const applyAndStart = async () => {
+							settings.repoName = repoName;
+							settings.repoId = repoId;
+							settings.repoToken = info.token;
+							settings.encrypted = info.encrypted;
+							settings.encVersion = info.enc_version;
+							settings.repoSalt = info.salt;
+							settings.repoMagic = info.magic;
+							settings.randomKey = info.random_key;
+							repoSetting.setDesc(repoName);
+							await this.plugin.saveSettings();
+							if (settings.enableSync) this.plugin.sync.startSync();
+						};
 
-						if (settings.enableSync) this.plugin.sync.startSync();
+						if (info.encrypted) {
+							if (info.enc_version !== 2 && info.enc_version !== 4) {
+								new Notice(`Encryption version ${info.enc_version} is not supported. Only v2 and v4 work.`);
+								return;
+							}
+							new PasswordModal(this.app, {
+								repoId,
+								encVersion: info.enc_version,
+								repoSalt: info.salt,
+								magic: info.magic,
+								randomKey: info.random_key
+							}, async (crypto) => {
+								server.crypto = crypto;
+								await applyAndStart();
+							}).open();
+						} else {
+							server.crypto = null;
+							await applyAndStart();
+						}
 					}).open();
 				});
 			});

--- a/src/ui/setting_tab.ts
+++ b/src/ui/setting_tab.ts
@@ -191,6 +191,21 @@ export class SeafileSettingTab extends PluginSettingTab {
 				});
 			});
 
+		new Setting(containerEl)
+			.setName("Manual sync")
+			.setDesc("Trigger a sync immediately.")
+			.addButton(button => button
+				.setButtonText("Sync now")
+				.onClick(async () => {
+					button.setDisabled(true);
+					try {
+						await this.plugin.triggerManualSync();
+					} finally {
+						button.setDisabled(false);
+					}
+				})
+			);
+
 		let intervalText: TextComponent;
 		new Setting(containerEl)
 			.setName("Sync interval")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,6 +204,22 @@ export async function computeBlocks(buffer: ArrayBuffer): Promise<Record<string,
 	return blocks;
 }
 
+// For encrypted repos: split into 8MB chunks, AES-CBC encrypt each, key by SHA1(ciphertext).
+// Insertion order is preserved so the resulting block_ids align with file offsets on download.
+export async function computeBlocksEncrypted(buffer: ArrayBuffer, encrypt: (chunk: ArrayBuffer) => Promise<ArrayBuffer>): Promise<Record<string, ArrayBuffer>> {
+	const size = buffer.byteLength;
+	const blocks: Record<string, ArrayBuffer> = {};
+	const blockSize = 8 * 1024 * 1024;
+	const numBlocks = Math.ceil(size / blockSize);
+	for (let i = 0; i < numBlocks; i++) {
+		const plain = buffer.slice(i * blockSize, (i + 1) * blockSize);
+		const cipher = await encrypt(plain);
+		const hash = await sha1(cipher);
+		blocks[hash] = cipher;
+	}
+	return blocks;
+}
+
 // Faster way to convert an array buffer to a base64 string
 export async function arrayBufferToBase64(buffer: ArrayBuffer): Promise<string> {
 	return await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary

Two independent features bundled together. Happy to split into two PRs if preferred.

### 1. Encrypted repository support (`9c29e32`)
Adds support for end-to-end encrypted Seafile libraries (enc_version 2 and 4).

- New `src/crypto.ts` (~160 lines): PBKDF2 key derivation, AES-256-CBC encrypt/decrypt, magic verification.
- New `src/ui/password_modal.ts`: passphrase prompt + magic check.
- `RepoModal` now branches on `info.encrypted` and opens the password modal before saving the repo.
- `enableSync()` calls a new `ensureUnlocked()` guard that prompts for the password if the user reopens Obsidian against an encrypted repo.
- Settings extended with `encrypted`, `encVersion`, `repoSalt`, `repoMagic`, `randomKey`.
- `server.crypto` is cleared on logout and on repo change.

Unsupported encryption versions (anything other than 2 or 4) show a Notice and don't proceed.

### 2. Manual sync button and command (`3504fff`)
Adds a way to trigger a sync immediately without waiting for the interval tick.

- "Manual sync" row in the settings tab (between "Sync status" and "Sync interval") with a "Sync now" button.
- "Seafile: Sync now" command in the command palette, assignable to a hotkey.
- Both surfaces share `triggerManualSync()` on the plugin, which guards on the existing readiness checks (sync enabled, logged in, repo selected, not already busy) and shows a Notice for each branch.

## Motivation
- E2E: lets people who already encrypt their Seafile libraries actually use this plugin against them. Without it, the plugin downloads raw encrypted blocks and writes them as note contents.
- Manual sync: useful before closing the laptop, switching to mobile, or after editing a bunch of files when 30 seconds feels too long.

## Test plan
- [x] `npm run build` succeeds (typecheck + esbuild production).
- [x] Plain (unencrypted) repos behave identically to before.
- [x] Encrypted repo (v2 and v4) prompts for password on repo selection, decrypts pulled blocks, encrypts pushed blocks.
- [x] Wrong password → magic verification fails, sync does not start.
- [x] Logout / repo change clears `server.crypto` and the encryption settings.
- [x] Settings → "Sync now" triggers a cycle when ready.
- [x] Command palette → "Seafile: Sync now" triggers a cycle when ready.
- [x] Appropriate Notice shown when not logged in, no repo, sync disabled, or sync already busy.

Happy to split into two separate PRs if you'd prefer to review them independently.